### PR TITLE
Remove ScanBridges

### DIFF
--- a/bridge.proto
+++ b/bridge.proto
@@ -13,11 +13,6 @@ service BridgeManagerService {
   rpc ListBridges(QueryBridgesRequest) returns (QueryBridgesResponse);
 
   /**
-   * Scan for new bridges.
-   */
-  rpc ScanBridges(QueryBridgesRequest) returns (QueryBridgesResponse);
-
-  /**
    * List already connected bridges.
    */
   rpc ConnectedBridges(QueryBridgesRequest) returns (QueryBridgesResponse);


### PR DESCRIPTION
Merge ScanBridges with ListBridges, I think the distinction for Scan and List is likely a Summit specific quirk. Merging these two endpoints simplifies the API.